### PR TITLE
GI-108: Set absolute paths for prod

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -5,7 +5,8 @@ module.exports = {
       script: "server/dist/index.js",
       cwd: "/home/deployuser/projects/TechStudyFinder",
       env: {
-        DEPLOY_SCRIPT_PATH: "/home/deployuser/projects/TechStudyFinder/scripts/deploy.sh",
+        DEPLOY_SCRIPT_PATH:
+          "/home/deployuser/projects/TechStudyFinder/scripts/deploy.sh",
       },
     },
   ],


### PR DESCRIPTION
## Description

PM2 (process manager on prod) can't load `.env`, so the paths have to be set directly in the config

## Jira Ticket

Link to the Jira ticket: [GI-108](https://techstudyfinder.atlassian.net/browse/GI-108)

## Author Checklist

- [x] Code follows project coding standards and conventions
- [x] Tests have been written or updated
- [x] All tests pass locally
- [x] No sensitive data or secrets are included
- [x] Documentation (README, comments) has been updated if necessary

## Reviewer Notes

Please verify the following during review:

- The implementation matches the described requirements and Jira ticket
- Code changes are logically correct and maintainable
- No unnecessary dependencies or side effects introduced
- Tests cover critical logic and edge cases
- Naming, structure, and readability meet team standards

---

_Please ensure all criteria are met before merging._
