### PR TITLE
GI-108: Adjust proxy

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -29,7 +29,7 @@ if (!process.env.GITHUB_WEBHOOK_SECRET) {
 }
 
 const app = express();
-app.set("trust proxy", true);
+app.set("trust proxy", 1);
 const PORT = process.env.PORT || 5001;
 const clientDistPath = path.join(__dirname, "..", "..", "client", "dist");
 


### PR DESCRIPTION
## Description

Change `app.set("trust proxy", true)` to `app.set("trust proxy", 1)`. That way, only our nginx reverse proxy can access the backend (necessary for express-rate-limit)

## Jira Ticket

Link to the Jira ticket: [GI-108](https://techstudyfinder.atlassian.net/browse/GI-108)

## Author Checklist

- [x] Code follows project coding standards and conventions
- [x] Tests have been written or updated
- [x] All tests pass locally
- [x] No sensitive data or secrets are included
- [x] Documentation (README, comments) has been updated if necessary

## Reviewer Notes

Please verify the following during review:

- The implementation matches the described requirements and Jira ticket
- Code changes are logically correct and maintainable
- No unnecessary dependencies or side effects introduced
- Tests cover critical logic and edge cases
- Naming, structure, and readability meet team standards

---

_Please ensure all criteria are met before merging._
