### PR TITLE
GI-155: Add missing permissions for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Fehlende Permissions für GHA-Workflow bereitstellen, um `
denied: installation not allowed to Create organization package` zu fixen

- `contents: read`: erlaubt lesen von Repo Inhalten --> nötig für `actions/checkout`, um aktuellen Code zu holen
- `packages: write`: damit kann `GITHUB_TOKEN` Docker images in GHCR und Tags setzen (`:latest`); erlaubt auch `docker push`

## Jira Ticket

Link to the Jira ticket: [GI-155](https://techstudyfinder.atlassian.net/browse/GI-155)

## Author Checklist

- [x] Code follows project coding standards and conventions
- [x] Tests have been written or updated
- [x] All tests pass locally
- [x] No sensitive data or secrets are included
- [x] Documentation (README, comments) has been updated if necessary

## Reviewer Notes

Please verify the following during review:

- The implementation matches the described requirements and Jira ticket
- Code changes are logically correct and maintainable
- No unnecessary dependencies or side effects introduced
- Tests cover critical logic and edge cases
- Naming, structure, and readability meet team standards

## Additional Context (optional)

Hinzugefügt, da aktuelle Implementierung wegen dieser fehlenden Permissions failed

---

_Please ensure all criteria are met before merging._
