### PR TITLE
GI-155: Remove 'HOST' from index.ts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -39,7 +39,7 @@ if (!process.env.GITHUB_WEBHOOK_SECRET) {
 const app = express();
 app.set("trust proxy", 1);
 const PORT = Number(process.env.PORT) || 5001;
-const HOST = process.env.HOST || "127.0.0.1";
+
 const clientDistPath =
   process.env.CLIENT_DIST_PATH ||
   path.join(__dirname, "..", "..", "client", "dist");
@@ -118,9 +118,9 @@ app.use(((err: Error, _req: Request, res: Response, _next: NextFunction) => {
 }) as ErrorRequestHandler);
 
 if (require.main === module) {
-  server = app.listen(PORT, HOST, () => {
+  server = app.listen(PORT, () => {
     // eslint-disable-next-line no-console
-    console.log(`Backend running on http://${HOST}:${PORT}`);
+    console.log(`Backend running on ${PORT}`);
   });
 }
 


### PR DESCRIPTION
## Description

Removing `HOST` because Node should automatically bind to "0.0.0.0". This way, docker-port-mapping works and the `curl (56)` shouldn't appear during deployment anymore.

## Jira Ticket

Link to the Jira ticket: [GI-155](https://techstudyfinder.atlassian.net/browse/GI-155)

## Author Checklist

- [x] Code follows project coding standards and conventions
- [x] Tests have been written or updated
- [x] All tests pass locally
- [x] No sensitive data or secrets are included
- [x] Documentation (README, comments) has been updated if necessary

## Reviewer Notes

Please verify the following during review:

- The implementation matches the described requirements and Jira ticket
- Code changes are logically correct and maintainable
- No unnecessary dependencies or side effects introduced
- Tests cover critical logic and edge cases
- Naming, structure, and readability meet team standards

---

_Please ensure all criteria are met before merging._
